### PR TITLE
Use maxretry default value correctly, enable by default, fix formatting

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
   apt:
     pkg: fail2ban
     state: latest
+  tags: fail2ban
 
 - name: fail2ban | Make sure the fail2ban configuration is up to date
   template:
@@ -14,6 +15,7 @@
     mode: 0644
   notify:
     - restart fail2ban
+  tags: fail2ban
 
 - name: fail2ban | Make sure the fail2ban jail configuration is up to date
   template:
@@ -24,8 +26,10 @@
     mode: 0644
   notify:
     - restart fail2ban
+  tags: fail2ban
 
 - name: fail2ban | Make sure fail2ban is enabled
   service:
     name: fail2ban
     enabled: yes
+  tags: fail2ban

--- a/templates/etc_fail2ban_jail.conf.j2
+++ b/templates/etc_fail2ban_jail.conf.j2
@@ -92,21 +92,20 @@ action = %({{fail2ban_action}})s
 
 
 {% for service in fail2ban_services %}
-[{{service.name}}]
-
-enabled = {{service.enabled}}
-port = {{service.port}}
-filter = {{service.filter}}
-logpath = {{service.logpath}}
-maxretry = {{service.maxretry}}
+[{{ service.name }}]
+enabled = {{ service.enabled | default('true') }}
+port = {{ service.port }}
+filter = {{ service.filter }}
+logpath = {{ service.logpath }}
+maxretry = {{ service.maxretry | default (fail2ban_jail_maxretry_default) }}
 {% if service.protocol is defined %}
-protocol = {{service.protocol}}
+protocol = {{ service.protocol }}
 {% endif %}
 {% if service.action is defined %}
-action = %({{service.action}})s
+action = %({{ service.action }})s
 {% endif %}
 {% if service.banaction is defined %}
-banaction = {{service.banaction}}
+banaction = {{ service.banaction }}
 {% endif %}
 
 {% endfor %}

--- a/templates/etc_fail2ban_jail.conf.j2
+++ b/templates/etc_fail2ban_jail.conf.j2
@@ -18,20 +18,20 @@
 [DEFAULT]
 
 # "ignoreip" can be an IP address, a CIDR mask or a DNS host
-ignoreip = {{fail2ban_ignoreip}}
-bantime  = {{fail2ban_bantime}}
-maxretry = {{fail2ban_maxretry}}
+ignoreip = {{ fail2ban_ignoreip }}
+bantime  = {{ fail2ban_bantime }}
+maxretry = {{ fail2ban_maxretry }}
 
 # "backend" specifies the backend used to get files modification. Available
 # options are "gamin", "polling" and "auto".
 # yoh: For some reason Debian shipped python-gamin didn't work as expected
 #      This issue left ToDo, so polling is default backend for now
-backend = {{fail2ban_backend}}
+backend = {{ fail2ban_backend }}
 
 #
 # Destination email address used solely for the interpolations in
 # jail.{conf,local} configuration files.
-destemail = {{fail2ban_destemail}}
+destemail = {{ fail2ban_destemail}}
 
 #
 # ACTIONS
@@ -41,18 +41,18 @@ destemail = {{fail2ban_destemail}}
 # iptables-multiport, shorewall, etc) It is used to define
 # action_* variables. Can be overridden globally or per
 # section within jail.local file
-banaction = {{fail2ban_banaction}}
+banaction = {{ fail2ban_banaction }}
 
 # email action. Since 0.8.1 upstream fail2ban uses sendmail
 # MTA for the mailing. Change mta configuration parameter to mail
 # if you want to revert to conventional 'mail'.
-mta = {{fail2ban_mta}}
+mta = {{ fail2ban_mta }}
 
 # Default protocol
-protocol = {{fail2ban_protocol}}
+protocol = {{ fail2ban_protocol }}
 
 # Specify chain where jumps would need to be added in iptables-* actions
-chain = {{fail2ban_chain}}
+chain = {{ fail2ban_chain }}
 
 #
 # Action shortcuts. To be used to define action parameter
@@ -72,7 +72,7 @@ action_mwl = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(proto
 # Choose default action.  To change, just override value of 'action' with the
 # interpolation to the chosen action shortcut (e.g.  action_mw, action_mwl, etc) in jail.local
 # globally (section [DEFAULT]) or per specific section
-action = %({{fail2ban_action}})s
+action = %({{ fail2ban_action}})s
 
 #
 # JAILS
@@ -97,7 +97,9 @@ enabled = {{ service.enabled | default('true') }}
 port = {{ service.port }}
 filter = {{ service.filter }}
 logpath = {{ service.logpath }}
-maxretry = {{ service.maxretry | default (fail2ban_jail_maxretry_default) }}
+{% if service.maxretry is defined %}
+maxretry = {{ service.maxretry }}
+{% endif %}
 {% if service.protocol is defined %}
 protocol = {{ service.protocol }}
 {% endif %}


### PR DESCRIPTION
Also fixes formatting according to the jinja2 docs: http://jinja.pocoo.org/docs/dev/templates/

It is sensible to assume that a role should be enabled if it is not set to be not enabled. Before, the maxretry value was always required which is not useful as there is `maxretry` in `[DEFAULT]` aswell.
