### PR TITLE
Add missing pidfile definition which caused logrotate errors

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ fail2ban_logtarget: "/var/log/fail2ban.log"
 fail2ban_syslog_target: "/var/log/fail2ban.log"
 fail2ban_syslog_facility: 1
 fail2ban_socket: /var/run/fail2ban/fail2ban.sock
+fail2ban_pidfile: /var/run/fail2ban/fail2ban.pid
 
 fail2ban_ignoreip: "127.0.0.1/8"
 fail2ban_bantime: 600

--- a/templates/etc_fail2ban_fail2ban.conf.j2
+++ b/templates/etc_fail2ban_fail2ban.conf.j2
@@ -15,17 +15,17 @@
 #          4 = DEBUG
 # Values:  NUM  Default:  3
 #
-loglevel = {{fail2ban_loglevel}}
+loglevel = {{ fail2ban_loglevel }}
 
 # Option:  logtarget
 # Notes.:  Set the log target. This could be a file, SYSLOG, STDERR or STDOUT.
 #          Only one log target can be specified.
 # Values:  STDOUT STDERR SYSLOG file  Default:  /var/log/fail2ban.log
 #
-logtarget = {{fail2ban_logtarget}}
+logtarget = {{ fail2ban_logtarget }}
 {% if fail2ban_logtarget == "SYSLOG" %}
-syslog-target = {{fail2ban_syslog_target}}
-syslog-facility = {{fail2ban_syslog_facility}}
+syslog-target = {{ fail2ban_syslog_target }}
+syslog-facility = {{ fail2ban_syslog_facility }}
 {% endif %}
 
 # Option: socket
@@ -34,5 +34,11 @@ syslog-facility = {{fail2ban_syslog_facility}}
 #         communicate with the server afterwards.
 # Values: FILE  Default:  /var/run/fail2ban/fail2ban.sock
 #
-socket = {{fail2ban_socket}}
+socket = {{ fail2ban_socket }}
 
+# Option: pidfile
+# Notes.: Set the PID file. This is used to store the process ID of the
+#         fail2ban server.
+# Values: [ FILE ]  Default: /var/run/fail2ban/fail2ban.pid
+#
+pidfile = {{ fail2ban_pidfile }}


### PR DESCRIPTION
Logrotate calls `fail2ban-client flushlogs`, which does output a
`WARNING 'pidfile' not defined in 'Definition'. Using default one: '/var/run/fail2ban/fail2ban.pid'`
when `pidfile` is not defined.

Also conform to more readable recommended jinja2 syntax.
