### PR TITLE
Add support for custom filters and actions

### DIFF
--- a/files/action.d/sample.conf
+++ b/files/action.d/sample.conf
@@ -1,0 +1,37 @@
+# Fail2Ban configuration file
+# This is a sample file and *must* be edited before use
+
+[INCLUDES]
+
+before =
+
+
+[Definition]
+
+# Option:  actionstart
+# Notes.:  command executed once at the start of Fail2Ban.
+# Values:  CMD
+#
+actionstart =
+
+# Option:  actionstop
+# Notes.:  command executed once at the end of Fail2Ban
+# Values:  CMD
+#
+actionstop =
+
+# Option:  actionban
+# Notes.:  command executed when banning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionban =
+
+# Option:  actionunban
+# Notes.:  command executed when unbanning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionunban =

--- a/files/filter.d/sample.conf
+++ b/files/filter.d/sample.conf
@@ -1,0 +1,9 @@
+# Fail2Ban configuration file
+# This is a sample file and *must* be edited before use
+
+[INCLUDES]
+before = common.conf
+
+[Definition]
+failregex =
+ignoreregex =

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,17 @@
     - restart fail2ban
   tags: fail2ban
 
+- name: fail2ban | Add custom ban actions
+  copy:
+    src: action.d/
+    dest: /etc/fail2ban/action.d/
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart fail2ban
+  tags: fail2ban
+
 - name: fail2ban | Make sure fail2ban is enabled
   service:
     name: fail2ban

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,17 @@
     - restart fail2ban
   tags: fail2ban
 
+- name: fail2ban | Add custom filters
+  copy:
+    src: filter.d/
+    dest: /etc/fail2ban/filter.d/
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart fail2ban
+  tags: fail2ban
+
 - name: fail2ban | Make sure fail2ban is enabled
   service:
     name: fail2ban


### PR DESCRIPTION
This adds support for custom filters and ban actions, which make fail2ban much more useful than its default setup.

Changes were tested with vagrant.